### PR TITLE
Add binds editor

### DIFF
--- a/midi_app_controller/gui/binds_editor.py
+++ b/midi_app_controller/gui/binds_editor.py
@@ -46,7 +46,7 @@ class ButtonBinds(QWidget):
         buttons : List[ControllerElement]
             List of all available buttons.
         button_binds : List[ButtonBind]
-            List of currentl binds.
+            List of current binds.
         actions : List[str]
             List of all actions available to bind.
         """

--- a/midi_app_controller/gui/binds_editor.py
+++ b/midi_app_controller/gui/binds_editor.py
@@ -1,6 +1,6 @@
 from typing import Callable, List
 
-# TODO Move style somewhere else to make this class independent from napari.
+# TODO Move style somewhere else in the future to make this class independent from napari.
 from napari.qt import get_current_stylesheet
 from qtpy.QtWidgets import (
     QWidget,
@@ -19,57 +19,97 @@ from midi_app_controller.models.controller import Controller, ControllerElement
 
 
 class ButtonBinds(QWidget):
+    """Widget that allows to change actions bound to each button.
+
+    Attributes
+    ----------
+    actions : List[str]
+        List of all actions available to bind and an empty string (used when
+        no action is bound).
+    button_menus : Tuple[int, QPushButton]
+        List of all pairs (button id, QPushButton used to set action). Each
+        QPushButton text is the currently selected action.
+    binds_dict : dict[int, ControllerElement]
+        Dictionary that allows to get a controller's button by its id.
+    """
+
     def __init__(
         self,
         buttons: List[ControllerElement],
         button_binds: List[ButtonBind],
         actions: List[str],
     ):
+        """Creates ButtonBinds widget.
+
+        Parameters
+        ----------
+        buttons : List[ControllerElement]
+            List of all available buttons.
+        button_binds : List[ButtonBind]
+            List of currentl binds.
+        actions : List[str]
+            List of all actions available to bind.
+        """
         super().__init__()
 
         self.actions = [""] + actions
         self.button_menus = []
         self.binds_dict = {b.button_id: b for b in button_binds}
 
-        self.layout = QVBoxLayout()
-
+        # Description row.
         description_layout = QHBoxLayout()
         description_layout.addWidget(QLabel("Name:"))
         description_layout.addWidget(QLabel("Action when clicked:"))
-        self.layout.addLayout(description_layout)
 
+        # All buttons available to bind.
         button_list = QWidget()
-        self.button_layout = QVBoxLayout()
+        button_layout = QVBoxLayout()
         for elem in buttons:
-            self._create_button_entry(elem.id, elem.name)
-        self.button_layout.addStretch()
-        button_list.setLayout(self.button_layout)
+            button_layout.addLayout(self._create_button_layout(elem.id, elem.name))
+        button_layout.addStretch()
+        button_list.setLayout(button_layout)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setWidget(button_list)
-        self.layout.addWidget(scroll)
 
-        self.layout.addStretch()
-        self.setLayout(self.layout)
+        # Layout.
+        layout = QVBoxLayout()
+        layout.addLayout(description_layout)
+        layout.addWidget(scroll)
+        layout.addStretch()
 
-    def _create_button_entry(self, button_id: int, button_name: str) -> None:
+        self.setLayout(layout)
+
+    def _create_button_layout(self, button_id: int, button_name: str) -> QHBoxLayout:
+        """Creates layout for a button.
+
+        The layout consists of button name and action selector. An entry is
+        added to the `self.button_menus`.
+        """
+        # Check if there is an action bound to the button.
         if (bind := self.binds_dict.get(button_id)) is not None:
             action = bind.action_id
         else:
             action = None
 
+        # QPushButton with menu.
         button_action = QPushButton(action)
         button_action.setMenu(self._create_action_menu(button_action))
+
+        self.button_menus.append((button_id, button_action))
 
         layout = QHBoxLayout()
         layout.addWidget(QLabel(button_name))
         layout.addWidget(button_action)
-        self.button_layout.addLayout(layout)
 
-        self.button_menus.append((button_id, button_action))
+        return layout
 
     def _create_action_menu(self, button: QPushButton) -> QMenu:
+        """Creates a scrollable menu consisting of all `self.actions`.
+
+        When an action is selected, the text of `button` is set its name.
+        """
         menu = QMenu(self)
         menu.setStyleSheet("QMenu { menu-scrollable: 1; }")
         for action in self.actions:
@@ -77,6 +117,7 @@ class ButtonBinds(QWidget):
         return menu
 
     def get_binds(self) -> List[ButtonBind]:
+        """Returns list of all binds currently set in this widget."""
         result = []
         for button_id, button in self.button_menus:
             action = button.text() or None
@@ -86,49 +127,88 @@ class ButtonBinds(QWidget):
 
 
 class KnobBinds(QWidget):
+    """Widget that allows to change actions bound to each knob.
+
+    Attributes
+    ----------
+    actions : List[str]
+        List of all actions available to bind and an empty string (used when
+        no action is bound).
+    knob_menus : Tuple[int, QPushButton, QPushButton]
+        List of all triples (knob id, QPushButton used to set increase action,
+        QPushButton used to set decrease action). Each QPushButton text is
+        the currently selected action.
+    binds_dict : dict[int, ControllerElement]
+        Dictionary that allows to get a controller's knob by its id.
+    """
+
     def __init__(
         self,
         knobs: List[ControllerElement],
         knob_binds: List[KnobBind],
         actions: List[str],
     ):
+        """Creates KnobBinds widget.
+
+        Parameters
+        ----------
+        knobs : List[ControllerElement]
+            List of all available knobs.
+        knob_binds : List[KnobBind]
+            List of current binds.
+        actions : List[str]
+            List of all actions available to bind.
+        """
         super().__init__()
 
         self.actions = [""] + actions
         self.knob_menus = []
         self.binds_dict = {b.knob_id: b for b in knob_binds}
 
-        self.layout = QVBoxLayout()
-
+        # Description row.
         description_layout = QHBoxLayout()
         description_layout.addWidget(QLabel("Name:"))
         description_layout.addWidget(QLabel("Action when increased:"))
         description_layout.addWidget(QLabel("Action when decreased:"))
-        self.layout.addLayout(description_layout)
 
+        # All knobs available to bind.
         knob_list = QWidget()
         self.knob_layout = QVBoxLayout()
         for elem in knobs:
-            self._create_knob_entry(elem.id, elem.name)
+            self.knob_layout.addLayout(self._create_knob_layout(elem.id, elem.name))
         self.knob_layout.addStretch()
         knob_list.setLayout(self.knob_layout)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setWidget(knob_list)
-        self.layout.addWidget(scroll)
 
-        self.layout.addStretch()
-        self.setLayout(self.layout)
+        # Layout.
+        layout = QVBoxLayout()
+        layout.addLayout(description_layout)
+        layout.addWidget(scroll)
+        layout.addStretch()
+
+        self.setLayout(layout)
 
     def _create_action_menu(self, knob: QPushButton) -> QMenu:
+        """Creates a scrollable menu consisting of all `self.actions`.
+
+        When an action is selected, the text of `knob` is set its name.
+        """
         menu = QMenu(self)
         menu.setStyleSheet("QMenu { menu-scrollable: 1; }")
         for action in self.actions:
             menu.addAction(action, lambda action=action: knob.setText(action))
         return menu
 
-    def _create_knob_entry(self, knob_id: int, knob_name: str) -> None:
+    def _create_knob_layout(self, knob_id: int, knob_name: str) -> QHBoxLayout:
+        """Creates layout for a knob.
+
+        The layout consists of knob name and increase/decrease action selector.
+        An entry is added to the `self.knob_menus`.
+        """
+        # Check if there are any actions bound to the knob.
         if (bind := self.binds_dict.get(knob_id)) is not None:
             action_increase = bind.action_id_increase
             action_decrease = bind.action_id_decrease
@@ -136,20 +216,24 @@ class KnobBinds(QWidget):
             action_increase = ""
             action_decrease = ""
 
+        # QPushButton with menus.
         knob_increase = QPushButton(action_increase)
         knob_increase.setMenu(self._create_action_menu(knob_increase))
         knob_decrease = QPushButton(action_decrease)
         knob_decrease.setMenu(self._create_action_menu(knob_decrease))
 
+        self.knob_menus.append((knob_id, knob_increase, knob_decrease))
+
+        # Layout.
         layout = QHBoxLayout()
         layout.addWidget(QLabel(knob_name))
         layout.addWidget(knob_increase)
         layout.addWidget(knob_decrease)
 
-        self.knob_layout.addLayout(layout)
-        self.knob_menus.append((knob_id, knob_increase, knob_decrease))
+        return layout
 
     def get_binds(self) -> List[KnobBind]:
+        """Returns list of all binds currently set in this widget."""
         result = []
         for knob_id, knob_increase, knob_decrease in self.knob_menus:
             increase_action = knob_increase.text() or None
@@ -166,6 +250,23 @@ class KnobBinds(QWidget):
 
 
 class BindsEditor(QDialog):
+    """Widget that allows to change actions bound to each knob/button and
+    save them (or exit without saving).
+
+    Attributes
+    ----------
+    save_binds : Callable[[List[KnobBind], List[ButtonBind]], None]
+        Function called after "Save and exit" button is clicked.
+    knobs_radio : QRadioButton
+        Button that allows to switch binds view to knobs.
+    buttons_radio : QRadioButton
+        Button that allows to switch binds view to buttons.
+    knobs_widget : KnobBinds
+        Widget with binds editor for knobs.
+    buttonss_widget : KnobBinds
+        Widget with binds editor for buttons.
+    """
+
     def __init__(
         self,
         controller: Controller,
@@ -173,20 +274,44 @@ class BindsEditor(QDialog):
         actions: List[str],
         save_binds: Callable[[List[KnobBind], List[ButtonBind]], None],
     ):
+        """Creates BindsEditor widget.
+
+        Parameters
+        ---------
+        controller : Controller
+            Controller for which the binds are created.
+        binds : Binds
+            Current binds that the widget will be initialized with.
+        actions : List[str]
+            List of all actions available to bind.
+        save_binds : Callable[[List[KnobBind], List[ButtonBind]], None]
+            Function called after "Save and exit" button is clicked.
+        """
         super().__init__()
 
         self.save_binds = save_binds
 
-        self.save_and_exit_button = QPushButton("Save and exit")
-        self.save_and_exit_button.clicked.connect(self._save_and_exit)
-        self.exit_button = QPushButton("Exit")
-        self.exit_button.clicked.connect(self._exit)
+        # Save/exit buttons.
+        save_and_exit_button = QPushButton("Save and exit")
+        save_and_exit_button.clicked.connect(self._save_and_exit)
+        exit_button = QPushButton("Exit")
+        exit_button.clicked.connect(self._exit)
 
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(save_and_exit_button)
+        buttons_layout.addWidget(exit_button)
+
+        # Radio buttons for switching knobs/buttons view.
         self.knobs_radio = QRadioButton("Knobs")
         self.buttons_radio = QRadioButton("Buttons")
-        self.knobs_radio.toggled.connect(self._on_radio_toggled)
-        self.buttons_radio.toggled.connect(self._on_radio_toggled)
+        self.knobs_radio.toggled.connect(self._switch_editors)
+        self.buttons_radio.toggled.connect(self._switch_editors)
 
+        radio_layout = QHBoxLayout()
+        radio_layout.addWidget(self.knobs_radio)
+        radio_layout.addWidget(self.buttons_radio)
+
+        # Bind editors.
         self.knobs_widget = KnobBinds(
             controller.knobs,
             binds.knob_binds,
@@ -198,14 +323,7 @@ class BindsEditor(QDialog):
             actions,
         )
 
-        radio_layout = QHBoxLayout()
-        radio_layout.addWidget(self.knobs_radio)
-        radio_layout.addWidget(self.buttons_radio)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(self.save_and_exit_button)
-        buttons_layout.addWidget(self.exit_button)
-
+        # Layout.
         layout = QVBoxLayout()
         layout.addLayout(radio_layout)
         layout.addLayout(buttons_layout)
@@ -215,10 +333,10 @@ class BindsEditor(QDialog):
         self.setLayout(layout)
         self.setStyleSheet(get_current_stylesheet())
         self.knobs_radio.setChecked(True)
-
         self.setMinimumSize(500, 550)
 
-    def _on_radio_toggled(self, checked):
+    def _switch_editors(self, checked):
+        """Switches binds editor view for knobs/buttons based on checked radio."""
         if not checked:
             return
         if self.knobs_radio.isChecked():
@@ -229,10 +347,12 @@ class BindsEditor(QDialog):
             self.buttons_widget.show()
 
     def _save_and_exit(self):
+        """Saves the binds and closes the widget."""
         knob_binds = self.knobs_widget.get_binds()
         button_binds = self.buttons_widget.get_binds()
         self.save_binds(knob_binds, button_binds)
-        self.close()
+        self._exit()
 
     def _exit(self):
+        """Closes the widget."""
         self.close()

--- a/midi_app_controller/gui/binds_editor.py
+++ b/midi_app_controller/gui/binds_editor.py
@@ -1,0 +1,238 @@
+from typing import Callable, List
+
+# TODO Move style somewhere else to make this class independent from napari.
+from napari.qt import get_current_stylesheet
+from qtpy.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QLabel,
+    QHBoxLayout,
+    QMenu,
+    QRadioButton,
+    QDialog,
+    QScrollArea,
+)
+
+from midi_app_controller.models.binds import ButtonBind, KnobBind, Binds
+from midi_app_controller.models.controller import Controller, ControllerElement
+
+
+class ButtonBinds(QWidget):
+    def __init__(
+        self,
+        buttons: List[ControllerElement],
+        button_binds: List[ButtonBind],
+        actions: List[str],
+    ):
+        super().__init__()
+
+        self.actions = [""] + actions
+        self.button_menus = []
+        self.binds_dict = {b.button_id: b for b in button_binds}
+
+        self.layout = QVBoxLayout()
+
+        description_layout = QHBoxLayout()
+        description_layout.addWidget(QLabel("Name:"))
+        description_layout.addWidget(QLabel("Action when clicked:"))
+        self.layout.addLayout(description_layout)
+
+        button_list = QWidget()
+        self.button_layout = QVBoxLayout()
+        for elem in buttons:
+            self._create_button_entry(elem.id, elem.name)
+        self.button_layout.addStretch()
+        button_list.setLayout(self.button_layout)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(button_list)
+        self.layout.addWidget(scroll)
+
+        self.layout.addStretch()
+        self.setLayout(self.layout)
+
+    def _create_button_entry(self, button_id: int, button_name: str) -> None:
+        if (bind := self.binds_dict.get(button_id)) is not None:
+            action = bind.action_id
+        else:
+            action = None
+
+        button_action = QPushButton(action)
+        button_action.setMenu(self._create_action_menu(button_action))
+
+        layout = QHBoxLayout()
+        layout.addWidget(QLabel(button_name))
+        layout.addWidget(button_action)
+        self.button_layout.addLayout(layout)
+
+        self.button_menus.append((button_id, button_action))
+
+    def _create_action_menu(self, button: QPushButton) -> QMenu:
+        menu = QMenu(self)
+        menu.setStyleSheet("QMenu { menu-scrollable: 1; }")
+        for action in self.actions:
+            menu.addAction(action, lambda action=action: button.setText(action))
+        return menu
+
+    def get_binds(self) -> List[ButtonBind]:
+        result = []
+        for button_id, button in self.button_menus:
+            action = button.text() or None
+            if action is not None:
+                result.append(ButtonBind(button_id=button_id, action_id=action))
+        return result
+
+
+class KnobBinds(QWidget):
+    def __init__(
+        self,
+        knobs: List[ControllerElement],
+        knob_binds: List[KnobBind],
+        actions: List[str],
+    ):
+        super().__init__()
+
+        self.actions = [""] + actions
+        self.knob_menus = []
+        self.binds_dict = {b.knob_id: b for b in knob_binds}
+
+        self.layout = QVBoxLayout()
+
+        description_layout = QHBoxLayout()
+        description_layout.addWidget(QLabel("Name:"))
+        description_layout.addWidget(QLabel("Action when increased:"))
+        description_layout.addWidget(QLabel("Action when decreased:"))
+        self.layout.addLayout(description_layout)
+
+        knob_list = QWidget()
+        self.knob_layout = QVBoxLayout()
+        for elem in knobs:
+            self._create_knob_entry(elem.id, elem.name)
+        self.knob_layout.addStretch()
+        knob_list.setLayout(self.knob_layout)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(knob_list)
+        self.layout.addWidget(scroll)
+
+        self.layout.addStretch()
+        self.setLayout(self.layout)
+
+    def _create_action_menu(self, knob: QPushButton) -> QMenu:
+        menu = QMenu(self)
+        menu.setStyleSheet("QMenu { menu-scrollable: 1; }")
+        for action in self.actions:
+            menu.addAction(action, lambda action=action: knob.setText(action))
+        return menu
+
+    def _create_knob_entry(self, knob_id: int, knob_name: str) -> None:
+        if (bind := self.binds_dict.get(knob_id)) is not None:
+            action_increase = bind.action_id_increase
+            action_decrease = bind.action_id_decrease
+        else:
+            action_increase = ""
+            action_decrease = ""
+
+        knob_increase = QPushButton(action_increase)
+        knob_increase.setMenu(self._create_action_menu(knob_increase))
+        knob_decrease = QPushButton(action_decrease)
+        knob_decrease.setMenu(self._create_action_menu(knob_decrease))
+
+        layout = QHBoxLayout()
+        layout.addWidget(QLabel(knob_name))
+        layout.addWidget(knob_increase)
+        layout.addWidget(knob_decrease)
+
+        self.knob_layout.addLayout(layout)
+        self.knob_menus.append((knob_id, knob_increase, knob_decrease))
+
+    def get_binds(self) -> List[KnobBind]:
+        result = []
+        for knob_id, knob_increase, knob_decrease in self.knob_menus:
+            increase_action = knob_increase.text() or None
+            decrease_action = knob_decrease.text() or None
+            if increase_action is not None or decrease_action is not None:
+                result.append(
+                    KnobBind(
+                        knob_id=knob_id,
+                        action_id_increase=increase_action,
+                        action_id_decrease=decrease_action,
+                    )
+                )
+        return result
+
+
+class BindsEditor(QDialog):
+    def __init__(
+        self,
+        controller: Controller,
+        binds: Binds,
+        actions: List[str],
+        save_binds: Callable[[List[KnobBind], List[ButtonBind]], None],
+    ):
+        super().__init__()
+
+        self.save_binds = save_binds
+
+        self.save_and_exit_button = QPushButton("Save and exit")
+        self.save_and_exit_button.clicked.connect(self._save_and_exit)
+        self.exit_button = QPushButton("Exit")
+        self.exit_button.clicked.connect(self._exit)
+
+        self.knobs_radio = QRadioButton("Knobs")
+        self.buttons_radio = QRadioButton("Buttons")
+        self.knobs_radio.toggled.connect(self._on_radio_toggled)
+        self.buttons_radio.toggled.connect(self._on_radio_toggled)
+
+        self.knobs_widget = KnobBinds(
+            controller.knobs,
+            binds.knob_binds,
+            actions,
+        )
+        self.buttons_widget = ButtonBinds(
+            controller.buttons,
+            binds.button_binds,
+            actions,
+        )
+
+        radio_layout = QHBoxLayout()
+        radio_layout.addWidget(self.knobs_radio)
+        radio_layout.addWidget(self.buttons_radio)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(self.save_and_exit_button)
+        buttons_layout.addWidget(self.exit_button)
+
+        layout = QVBoxLayout()
+        layout.addLayout(radio_layout)
+        layout.addLayout(buttons_layout)
+        layout.addWidget(self.knobs_widget)
+        layout.addWidget(self.buttons_widget)
+
+        self.setLayout(layout)
+        self.setStyleSheet(get_current_stylesheet())
+        self.knobs_radio.setChecked(True)
+
+        self.setMinimumSize(500, 550)
+
+    def _on_radio_toggled(self, checked):
+        if not checked:
+            return
+        if self.knobs_radio.isChecked():
+            self.buttons_widget.hide()
+            self.knobs_widget.show()
+        else:
+            self.knobs_widget.hide()
+            self.buttons_widget.show()
+
+    def _save_and_exit(self):
+        knob_binds = self.knobs_widget.get_binds()
+        button_binds = self.buttons_widget.get_binds()
+        self.save_binds(knob_binds, button_binds)
+        self.close()
+
+    def _exit(self):
+        self.close()

--- a/midi_app_controller/gui/binds_editor.py
+++ b/midi_app_controller/gui/binds_editor.py
@@ -263,7 +263,7 @@ class BindsEditor(QDialog):
         Button that allows to switch binds view to buttons.
     knobs_widget : KnobBinds
         Widget with binds editor for knobs.
-    buttonss_widget : KnobBinds
+    buttons_widget : ButtonBinds
         Widget with binds editor for buttons.
     """
 

--- a/midi_app_controller/gui/midi_status.py
+++ b/midi_app_controller/gui/midi_status.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pathlib
 from typing import List
 
@@ -51,10 +52,12 @@ class MidiStatus(QWidget):
         editor_dialog.exec_()
 
 
-if __name__ == "__main__":
-    import sys
-
-    app = QApplication([sys.argv])
+def main():
+    app = QApplication(sys.argv)
     view = MidiStatus()
     view.show()
     sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/midi_app_controller/gui/midi_status.py
+++ b/midi_app_controller/gui/midi_status.py
@@ -1,0 +1,58 @@
+import os
+import pathlib
+from typing import List
+
+from qtpy.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton
+
+from midi_app_controller.models.binds import ButtonBind, KnobBind, Binds
+from midi_app_controller.models.controller import Controller
+from midi_app_controller.gui.binds_editor import BindsEditor
+
+
+class MidiStatus(QWidget):
+    def __init__(self):
+        super().__init__()
+
+        self.button = QPushButton("Edit binds")
+        self.button.clicked.connect(self.on_button_clicked)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.button)
+        self.setLayout(layout)
+
+    def on_button_clicked(self):
+        # TODO Open real config files. It must wait until state manager is merged.
+        current_path = pathlib.Path(__file__).parent.resolve()
+        controller_path = os.path.join(current_path, "sample_controller.yaml")
+        binds_path = os.path.join(current_path, "sample_binds.yaml")
+
+        controller = Controller.load_from(controller_path)
+        binds = Binds.load_from(binds_path)
+
+        def save(knob_binds: List[KnobBind], button_binds: List[ButtonBind]) -> None:
+            print(knob_binds)
+            print(button_binds)
+            binds.knob_binds = knob_binds
+            binds.button_binds = button_binds
+            binds.save_to(binds_path)
+
+        sample_actions = ["Action1", "incr", "decr", "other"] + [
+            f"a{x}" for x in range(100)
+        ]
+
+        editor_dialog = BindsEditor(
+            controller,
+            binds,
+            sample_actions,
+            save,
+        )
+        editor_dialog.exec_()
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication([sys.argv])
+    view = MidiStatus()
+    view.show()
+    sys.exit(app.exec_())

--- a/midi_app_controller/gui/midi_status.py
+++ b/midi_app_controller/gui/midi_status.py
@@ -38,14 +38,14 @@ class MidiStatus(QWidget):
             binds.button_binds = button_binds
             binds.save_to(binds_path)
 
-        sample_actions = ["Action1", "incr", "decr", "other"] + [
-            f"a{x}" for x in range(100)
-        ]
+        from napari._app_model import get_app
+
+        actions = list(map(lambda x: x[0], list(get_app().commands)))
 
         editor_dialog = BindsEditor(
             controller,
             binds,
-            sample_actions,
+            actions,
             save,
         )
         editor_dialog.exec_()

--- a/midi_app_controller/gui/midi_status.py
+++ b/midi_app_controller/gui/midi_status.py
@@ -10,6 +10,8 @@ from midi_app_controller.gui.binds_editor import BindsEditor
 
 
 class MidiStatus(QWidget):
+    """Widget that allows to select currently used controller, binds, etc."""
+
     def __init__(self):
         super().__init__()
 

--- a/midi_app_controller/gui/sample_binds.yaml
+++ b/midi_app_controller/gui/sample_binds.yaml
@@ -1,0 +1,15 @@
+app_name: TestApp
+button_binds:
+- action_id: a56
+  button_id: 0
+- action_id: Action1
+  button_id: 1
+controller_name: TestController
+description: Test description
+knob_binds:
+- action_id_increase: a17
+  knob_id: 2
+- action_id_decrease: a63
+  action_id_increase: a63
+  knob_id: 3
+name: TestBinds

--- a/midi_app_controller/gui/sample_controller.yaml
+++ b/midi_app_controller/gui/sample_controller.yaml
@@ -1,0 +1,15 @@
+button_value_off: 11
+button_value_on: 100
+buttons:
+- id: 0
+  name: Button1
+- id: 1
+  name: Button2
+knob_value_max: 55
+knob_value_min: 33
+knobs:
+- id: 2
+  name: Knob1
+- id: 3
+  name: Knob2
+name: TestController

--- a/midi_app_controller/models/binds.py
+++ b/midi_app_controller/models/binds.py
@@ -33,8 +33,8 @@ class KnobBind(BaseModel):
     """
 
     knob_id: int = Field(ge=0, le=127)
-    action_id_increase: str
-    action_id_decrease: str
+    action_id_increase: Optional[str]
+    action_id_decrease: Optional[str]
 
 
 class Binds(YamlBaseModel):

--- a/midi_app_controller/napari.yaml
+++ b/midi_app_controller/napari.yaml
@@ -1,10 +1,9 @@
 name: midi-app-controller
 contributions:
   commands:
-    - id: midi-app-controller.example.toggle_viewer_scale_bar
-      title: Toggle viewer scale bar
-      python_name: midi_app_controller.example:toggle_viewer_scale_bar
+    - id: midi-app-controller.midi_status
+      title: Show MIDI controller status and settings
+      python_name: midi_app_controller.gui.midi_status:MidiStatus
   widgets:
-    - command: midi-app-controller.example.toggle_viewer_scale_bar
-      display_name: Toggle viewer scale bar
-      autogenerate: true
+    - command: midi-app-controller.midi_status
+      display_name: MIDI controller status and settings


### PR DESCRIPTION
Graphical interface for editing binds. Can be opened from the napari interface.

I hard-coded sample files paths so you may test loading/saving the data. File selection is not implemented in this PR (because #16 is needed for this).