### PR TITLE
Add GUI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
+    env:
+      DISPLAY: ':99.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,6 +24,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: pyproject.toml
+
+      - name: Install system dependencies for gui testing (libxkbcommon-x11-0)
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1 libdbus-1-3
+          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
 
       - name: Install dependencies
         run: pip install -e .[testing]

--- a/midi_app_controller/gui/_tests/test_binds_editor.py
+++ b/midi_app_controller/gui/_tests/test_binds_editor.py
@@ -1,0 +1,402 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app_model import Action
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
+
+from midi_app_controller.controller.connected_controller import ConnectedController
+from midi_app_controller.gui.binds_editor import BindsEditor, ButtonBinds, KnobBinds
+from midi_app_controller.gui.utils import HIGHLIGHT_DURATION_MS
+from midi_app_controller.models.binds import Binds, ButtonBind, KnobBind
+from midi_app_controller.models.controller import Controller, ControllerElement
+
+
+def list_of_actions(actions: list[str]) -> list[Action]:
+    return [
+        Action(id=action, title=action, callback=lambda: None) for action in actions
+    ]
+
+
+@pytest.fixture
+def controller_sample() -> Controller:
+    buttons = [
+        ControllerElement(id=1, name="Play"),
+        ControllerElement(id=2, name="Stop"),
+    ]
+    knobs = [
+        ControllerElement(id=3, name="Volume"),
+        ControllerElement(id=4, name="Zoom"),
+    ]
+    return Controller(
+        name="TestController",
+        button_value_off=0,
+        button_value_on=127,
+        knob_value_min=0,
+        knob_value_max=127,
+        buttons=buttons,
+        knobs=knobs,
+        default_channel=1,
+    )
+
+
+@pytest.fixture
+def button_binds_list() -> list[ButtonBind]:
+    return [
+        ButtonBind(button_id=1, action_id="play_action"),
+        ButtonBind(button_id=2, action_id="stop_action"),
+    ]
+
+
+@pytest.fixture
+def knob_binds_list() -> list[KnobBind]:
+    return [
+        KnobBind(
+            knob_id=3, action_id_increase="volume_up", action_id_decrease="volume_down"
+        ),
+        KnobBind(
+            knob_id=4, action_id_increase="zoom_in", action_id_decrease="zoom_out"
+        ),
+    ]
+
+
+@pytest.fixture
+def mixed_knob_binds_list() -> list[KnobBind]:
+    return [KnobBind(knob_id=3, action_id_increase="volume_up", action_id_decrease="")]
+
+
+@pytest.fixture
+def binds_sample(button_binds_list, knob_binds_list) -> Binds:
+    return Binds(
+        name="TestBinds",
+        app_name="TestApp",
+        controller_name="TestController",
+        description="description",
+        button_binds=button_binds_list,
+        knob_binds=knob_binds_list,
+    )
+
+
+@pytest.fixture
+def button_binds(qtbot, controller_sample, button_binds_list) -> ButtonBinds:
+    actions_str = ["play_action", "stop_action"]
+    widget = ButtonBinds(
+        controller_sample.buttons,
+        button_binds_list,
+        list_of_actions(actions_str),
+        MagicMock(spec=ConnectedController),
+        QtWidgets.QCheckBox(),
+    )
+    widget.show()
+    qtbot.addWidget(widget)
+    return widget
+
+
+@pytest.fixture
+def knob_binds(qtbot, controller_sample, knob_binds_list) -> KnobBinds:
+    actions_str = ["volume_up", "volume_down", "zoom_in", "zoom_out"]
+    widget = KnobBinds(
+        controller_sample.knobs,
+        knob_binds_list,
+        list_of_actions(actions_str),
+        MagicMock(spec=ConnectedController),
+        QtWidgets.QCheckBox(),
+    )
+    qtbot.addWidget(widget)
+    return widget
+
+
+@pytest.fixture
+def knob_binds_mixed(qtbot, controller_sample, mixed_knob_binds_list) -> KnobBinds:
+    actions_str = ["volume_up", "volume_down", "zoom_in", "zoom_out"]
+    widget = KnobBinds(
+        controller_sample.knobs,
+        mixed_knob_binds_list,
+        list_of_actions(actions_str),
+        MagicMock(spec=ConnectedController),
+        QtWidgets.QCheckBox(),
+    )
+    qtbot.addWidget(widget)
+    return widget
+
+
+@pytest.fixture
+def binds_editor_basic(qtbot, controller_sample, binds_sample) -> BindsEditor:
+    actions_str = ["play_action", "volume_up", "volume_down", "zoom_in", "zoom_out"]
+    widget = BindsEditor(
+        controller_sample,
+        binds_sample,
+        list_of_actions(actions_str),
+        save_binds=lambda x: None,
+        connected_controller=MagicMock(spec=ConnectedController),
+    )
+    qtbot.addWidget(widget)
+    widget.show()
+    return widget
+
+
+@pytest.fixture
+def binds_editor(
+    qtbot, controller_sample, binds_sample
+) -> tuple[BindsEditor, patch, patch]:
+    with (
+        patch.object(BindsEditor, "_save_and_exit") as mock_save_and_exit,
+        patch.object(BindsEditor, "_exit") as mock_exit,
+    ):
+        actions_str = ["play_action", "volume_up", "volume_down", "zoom_in", "zoom_out"]
+        widget = BindsEditor(
+            controller_sample,
+            binds_sample,
+            list_of_actions(actions_str),
+            save_binds=lambda x: None,
+            connected_controller=MagicMock(spec=ConnectedController),
+        )
+        qtbot.addWidget(widget)
+        widget.show()
+        yield widget, mock_save_and_exit, mock_exit
+
+
+def test_button_binds_initialization(button_binds):
+    fixture = button_binds
+    expected_length = 2
+    assert len(fixture.button_combos) == expected_length
+
+
+def test_get_button_binds(button_binds):
+    expected_binds = ["play_action", "stop_action"]
+
+    binds = button_binds.get_binds()
+
+    assert len(binds) == len(expected_binds)
+    for i in range(len(binds)):
+        assert binds[i].action_id == expected_binds[i]
+
+
+@pytest.mark.parametrize(
+    "binds, expected_length", [("knob_binds", 2), ("knob_binds_mixed", 2)]
+)
+def test_knob_binds_initialization(request, binds, expected_length):
+    binds = request.getfixturevalue(binds)
+    assert len(binds.knob_combos) == expected_length
+
+
+@pytest.mark.parametrize(
+    "binds, expected_binds",
+    [
+        ("knob_binds", [("volume_up", "volume_down"), ("zoom_in", "zoom_out")]),
+        ("knob_binds_mixed", [("volume_up", None)]),
+    ],
+)
+def test_get_knob_binds(request, binds, expected_binds):
+    binds = request.getfixturevalue(binds).get_binds()
+    assert len(binds) == len(expected_binds)
+    for bind, (expected_increase, expected_decrease) in zip(binds, expected_binds):
+        assert bind.action_id_increase == expected_increase
+        assert bind.action_id_decrease == expected_decrease
+
+
+def test_binds_editor_save_and_exit(binds_editor):
+    widget, mock_save_and_exit, mock_exit = binds_editor
+    assert widget.save_and_exit_button is not None
+
+    QTest.mouseClick(widget.save_and_exit_button, Qt.LeftButton)
+    QTest.qWait(100)
+    mock_save_and_exit.assert_called_once()
+    mock_exit.assert_not_called()
+
+
+def test_binds_editor_exit(binds_editor):
+    widget, mock_save_and_exit, mock_exit = binds_editor
+    assert widget.exit_button is not None
+
+    QTest.mouseClick(widget.exit_button, Qt.LeftButton)
+    QTest.qWait(100)
+    mock_exit.assert_called_once()
+    mock_save_and_exit.assert_not_called()
+
+
+def test_binds_editor_save_and_exit_no_mock(binds_editor_basic):
+    save_and_exit_button = binds_editor_basic.save_and_exit_button
+    assert save_and_exit_button is not None
+
+    QTest.mouseClick(save_and_exit_button, Qt.LeftButton)
+    QTest.qWait(100)
+    assert not binds_editor_basic.isVisible()
+
+
+def test_binds_editor_exit_no_mock(binds_editor_basic):
+    widget = binds_editor_basic
+    exit_button = widget.exit_button
+    assert exit_button is not None
+    QTest.mouseClick(exit_button, Qt.LeftButton)
+    QTest.qWait(100)
+    assert not widget.isVisible()
+
+
+def test_button_binds_initialization_unbound(qtbot, controller_sample):
+    unbound_buttons = [ControllerElement(id=3, name="Unbound Button")]
+    actions_str = ["play_action", "stop_action"]
+    widget = ButtonBinds(
+        unbound_buttons,
+        [],
+        list_of_actions(actions_str),
+        MagicMock(spec=ConnectedController),
+        QtWidgets.QCheckBox(),
+    )
+    qtbot.addWidget(widget)
+
+    assert len(widget.button_combos) == 1
+    button_id = unbound_buttons[0].id
+    action_combo = widget.button_combos[button_id]
+    assert action_combo.currentText() == ""
+
+
+def test_knob_binds_initialization_unbound(qtbot, controller_sample):
+    unbound_knobs = [ControllerElement(id=5, name="Unbound Knob")]
+    actions_str = ["volume_up", "volume_down", "zoom_in", "zoom_out"]
+    widget = KnobBinds(
+        unbound_knobs,
+        [],
+        list_of_actions(actions_str),
+        MagicMock(spec=ConnectedController),
+        QtWidgets.QCheckBox(),
+    )
+    qtbot.addWidget(widget)
+
+    assert len(widget.knob_combos) == 1
+    knob_id = unbound_knobs[0].id
+    increase_action_combo, decrease_action_combo = widget.knob_combos[knob_id]
+    assert increase_action_combo.currentText() == ""
+    assert decrease_action_combo.currentText() == ""
+
+
+@pytest.mark.parametrize(
+    "button_id, action_id",
+    [
+        (1, "stop_action"),
+        (2, "play_action"),
+        (1, "play_action"),
+        (2, "stop_action"),
+    ],
+)
+def test_modify_bind_action(button_binds, button_id, action_id):
+    widget = button_binds
+    action_combo = widget.button_combos[button_id]
+    index = action_combo.findText(action_id)
+    action_combo.setCurrentIndex(index)
+    QTest.qWait(100)
+    assert action_combo.currentText() == action_id
+
+
+@pytest.mark.parametrize(
+    "stop, controller",
+    [
+        (True, None),
+        (False, None),
+        (False, MagicMock()),
+    ],
+)
+@pytest.mark.parametrize("button_id", [1, 2])
+def test_light_up_button(button_binds, stop, controller, button_id):
+    widget = button_binds
+    widget.stop = stop
+    widget.connected_controller = controller
+
+    if not widget.connected_controller and not stop:
+        with pytest.raises(Exception, match="No controller connected."):
+            widget._light_up_button(button_id)
+    else:
+        widget._light_up_button(button_id)
+        if controller and not stop:
+            QTest.qWait(100)
+            widget.connected_controller.flash_button.assert_called_with(button_id)
+        else:
+            if controller:
+                widget.connected_controller.flash_button.assert_not_called()
+
+
+@pytest.mark.parametrize("knob_id", [3, 4])
+def test_light_up_knob(knob_binds, knob_id):
+    widget = knob_binds
+    widget.connected_controller = MagicMock(spec=ConnectedController)
+    widget._light_up_knob(knob_id)
+    QTest.qWait(100)
+    widget.connected_controller.flash_knob.assert_called_with(knob_id)
+
+
+def test_wait_for_worker_threads(binds_editor_basic):
+    widget = binds_editor_basic
+    thread = MagicMock()
+    widget.buttons_widget.thread_list.append(thread)
+    widget.knobs_widget.thread_list.append(thread)
+    thread.wait = MagicMock()
+
+    widget._wait_for_worker_threads()
+    thread.wait.assert_called()
+
+
+@pytest.mark.parametrize("tab_index", [0, 1])
+def test_save_and_exit(binds_editor_basic, tab_index):
+    widget = binds_editor_basic
+    widget.tab_widget.setCurrentIndex(tab_index)
+    widget._save_and_exit()
+    assert not widget.isVisible()
+
+
+@pytest.mark.parametrize("tab_index", [0, 1])
+def test_exit(binds_editor_basic, tab_index):
+    widget = binds_editor_basic
+    widget.tab_widget.setCurrentIndex(tab_index)
+    widget._exit()
+    assert not widget.isVisible()
+
+
+@pytest.mark.parametrize(
+    "tab, bind_type, bind_id",
+    [
+        (0, "button", 1),
+        (0, "button", 2),
+        (1, "knob", 3),
+        (1, "knob", 4),
+    ],
+)
+def test_highlight_button_and_knob(binds_editor_basic, tab, bind_type, bind_id):
+    widget = binds_editor_basic
+    widget.tab_widget.setCurrentIndex(tab)
+
+    if bind_type == "button":
+        widget.buttons_widget.highlight_button(bind_id)
+        QTest.qWait(HIGHLIGHT_DURATION_MS + 100)
+        combo = widget.buttons_widget.button_combos[bind_id]
+        assert combo.styleSheet() == ""
+    else:
+        widget.knobs_widget.highlight_knob(bind_id)
+        QTest.qWait(HIGHLIGHT_DURATION_MS + 100)
+        combos = widget.knobs_widget.knob_combos[bind_id]
+        assert combos[0].styleSheet() == ""
+        assert combos[1].styleSheet() == ""
+
+
+@pytest.mark.parametrize("tab", [0, 1])
+def test_toggle_names_mode(binds_editor_basic, tab):
+    widget = binds_editor_basic
+    widget.tab_widget.setCurrentIndex(tab)
+
+    if tab == 0:
+        for combo1, combo2 in widget.knobs_widget.knob_combos.values():
+            combo1.toggle_names_mode = MagicMock()
+            combo2.toggle_names_mode = MagicMock()
+    else:
+        for combo in widget.buttons_widget.button_combos.values():
+            combo.toggle_names_mode = MagicMock()
+
+    widget._toggle_names_mode()
+
+    if tab == 0:
+        for combo1, combo2 in widget.knobs_widget.knob_combos.values():
+            combo1.toggle_names_mode.assert_called_once()
+            combo2.toggle_names_mode.assert_called_once()
+    else:
+        for combo in widget.buttons_widget.button_combos.values():
+            combo.toggle_names_mode.assert_called_once()

--- a/midi_app_controller/gui/_tests/test_midi_status.py
+++ b/midi_app_controller/gui/_tests/test_midi_status.py
@@ -1,0 +1,263 @@
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QMessageBox
+
+from midi_app_controller.gui.midi_status import get_state_manager, main
+from midi_app_controller.models.binds import Binds
+from midi_app_controller.models.controller import Controller
+from midi_app_controller.state.state_manager import SelectedItem
+
+
+@pytest.fixture(autouse=True)
+def patch_rtmidi() -> tuple:
+    midi_in_mock = MagicMock(name="MidiIn")
+    midi_out_mock = MagicMock(name="MidiOut")
+
+    with patch("rtmidi.MidiIn", new=midi_in_mock):  # noqa
+        with patch("rtmidi.MidiOut", new=midi_out_mock):  # noqa
+            state_manager = get_state_manager()
+            state_manager.selected_midi_in = "Midi Through:Midi Through Port-0 14:0"
+            state_manager.selected_midi_out = "Midi Through:Midi Through Port-0 14:0"
+
+            binds = [
+                SelectedItem(f"Binds {i + 1}", Path(f"/path/binds_{i + 1}.yaml"))
+                for i in range(3)
+            ]
+            controllers = [
+                SelectedItem(
+                    f"Controller {i + 1}", Path(f"/path/controller_{i + 1}.yaml")
+                )
+                for i in range(3)
+            ]
+            state_manager.get_available_binds = MagicMock(return_value=binds)
+            state_manager.get_available_controllers = MagicMock(
+                return_value=controllers
+            )
+
+            yield (
+                binds,
+                controllers,
+            )
+
+
+def create_binds(path):
+    path_str = str(path)
+    match = re.search(r"binds_(\d+)\.yaml$", path_str)
+    index = int(match.group(1))
+    mock = MagicMock(spec=Binds)
+    mock.name = f"Binds {index}"
+    mock.controller_name = f"Controller {(index - 1) % 3 + 1}"
+    mock.button_binds = []
+    mock.knob_binds = []
+    return mock
+
+
+def create_controller(path):
+    path_str = str(path)
+    match = re.search(r"controller_(\d+)\.yaml$", path_str)
+    index = match.group(1)
+    mock = MagicMock(spec=Controller)
+    mock.name = f"Controller {index}"
+    mock.buttons = []
+    mock.knobs = []
+    mock.knob_value_min = 0
+    mock.knob_value_max = 127
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def load_methods():
+    with (
+        patch(
+            "midi_app_controller.models.binds.Binds.load_from", side_effect=create_binds
+        ),
+        patch(
+            "midi_app_controller.models.controller.Controller.load_from",
+            side_effect=create_controller,
+        ),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def midi_status(qtbot, patch_rtmidi, load_methods):
+    from midi_app_controller.gui.midi_status import MidiStatus
+
+    widget = MidiStatus()
+    qtbot.addWidget(widget)
+    widget.show()
+    return widget
+
+
+def test_select_controller(midi_status, patch_rtmidi, qtbot):
+    binds_names, controller_names = patch_rtmidi
+    QTest.qWait(300)
+
+    for i in range(len(controller_names)):
+        QTest.qWait(300)
+        qtbot.keyClicks(midi_status.current_controller, controller_names[i].name)
+        QTest.qWait(300)
+        selected_controller = get_state_manager().selected_controller.name
+        assert selected_controller == controller_names[i].name
+
+
+def test_copy_binds(midi_status, qtbot, patch_rtmidi):
+    state_manager = get_state_manager()
+    state_manager.copy_binds = MagicMock()
+    state_manager.select_binds_path = MagicMock()
+    binds_names, controller_names = patch_rtmidi
+
+    qtbot.mouseClick(midi_status.copy_binds_button, Qt.LeftButton)
+    QTest.qWait(300)
+
+    assert not state_manager.copy_binds.called
+    assert not state_manager.select_binds_path.called
+
+    qtbot.keyClicks(midi_status.current_controller, controller_names[0].name)
+    QTest.qWait(300)
+    qtbot.keyClicks(midi_status.current_binds, binds_names[0].name)
+    QTest.qWait(300)
+
+    state_manager.copy_binds = MagicMock()
+    state_manager.select_binds_path = MagicMock()
+
+    qtbot.mouseClick(midi_status.copy_binds_button, Qt.LeftButton)
+
+    state_manager.copy_binds.assert_called_once()
+    state_manager.select_binds_path.assert_called_once()
+
+
+def test_start_stop_handling(midi_status, qtbot, patch_rtmidi):
+    qtbot.keyClicks(midi_status.current_controller, "Controller 1")
+    QTest.qWait(300)
+    qtbot.keyClicks(midi_status.current_binds, "Binds 1")
+
+    QTest.qWait(300)
+    assert midi_status.status.text() == "Not running"
+    qtbot.mouseClick(midi_status.start_handling_button, Qt.LeftButton)
+    QTest.qWait(300)
+    assert midi_status.status.text() == "Running"
+    qtbot.mouseClick(midi_status.stop_handling_button, Qt.LeftButton)
+    QTest.qWait(300)
+    assert midi_status.status.text() == "Not running"
+
+
+@patch("midi_app_controller.gui.midi_status.BindsEditor")
+def test_edit_binds(binds_editor_mock, midi_status, patch_rtmidi, qtbot):
+    binds_names, controller_names = patch_rtmidi
+    state_manager = get_state_manager()
+    QTest.qWait(500)
+    qtbot.keyClicks(midi_status.current_binds, "(none)")
+
+    for i in range(len(binds_names)):
+        QTest.qWait(500)
+        qtbot.keyClicks(midi_status.current_binds, binds_names[i].name)
+        QTest.qWait(500)
+
+        assert state_manager.selected_binds.name == binds_names[i].name
+        midi_status.edit_binds_button.click()
+        QTest.qWait(500)
+        assert binds_editor_mock.called
+        assert (
+            binds_editor_mock.call_args[0][0].name
+            == state_manager.selected_controller.name
+        )
+        assert (
+            binds_editor_mock.call_args[0][1].name == state_manager.selected_binds.name
+        )
+
+
+def test_edit_binds_exceptions(midi_status, patch_rtmidi):
+    state_manager = get_state_manager()
+    state_manager.selected_controller = None
+    state_manager.selected_binds = None
+
+    with pytest.raises(Exception, match="No controller selected."):
+        midi_status._edit_binds()
+
+    state_manager.selected_controller = SelectedItem(
+        "test_controller", Path("test_path")
+    )
+    with pytest.raises(Exception, match="No binds selected."):
+        midi_status._edit_binds()
+
+
+def test_refresh(midi_status, patch_rtmidi):
+    state_manager = get_state_manager()
+    state_manager.is_running = MagicMock(return_value=True)
+    midi_status.refresh()
+
+    assert midi_status.status.text() == "Running"
+    assert midi_status.start_handling_button.text() == "Restart handling"
+    assert midi_status.stop_handling_button.isEnabled() is True
+
+
+def test_select_binds(midi_status, patch_rtmidi):
+    state_manager = get_state_manager()
+    binds_names, _ = patch_rtmidi
+    new_binds = SelectedItem(binds_names[2].name, Path(""))
+
+    midi_status._select_binds(new_binds)
+    assert state_manager.selected_binds == new_binds
+
+
+@patch("midi_app_controller.gui.midi_status.BindsEditor")
+def test_edit_binds_with_subpath(
+    mock_binds_editor, load_methods, midi_status, patch_rtmidi, qtbot
+):
+    state_manager = get_state_manager()
+    state_manager.connected_controller = MagicMock()
+
+    qtbot.keyClicks(midi_status.current_controller, "Controller 1")
+    QTest.qWait(300)
+    qtbot.keyClicks(midi_status.current_binds, "Binds 1")
+    QTest.qWait(300)
+
+    controller = Controller.load_from(Path("/path/controller_1.yaml"))
+    binds = Binds.load_from(Path("/path/binds_1.yaml"))
+
+    midi_status._edit_binds()
+    assert mock_binds_editor.called
+    call_args = mock_binds_editor.call_args[0]
+
+    assert call_args[0].name == controller.name
+    assert call_args[1].name == binds.name
+
+
+def test_main():
+    with patch.object(sys, "exit") as mock_exit:  # noqa
+        with patch("midi_app_controller.gui.midi_status.QApplication") as q_app:
+            q_app.return_value = MagicMock()
+            with patch("midi_app_controller.gui.midi_status.MidiStatus") as midi_status:
+                main()
+                midi_status.assert_called_once()
+                mock_view_instance = midi_status.return_value
+                assert mock_view_instance.show.called
+                mock_exit.assert_called_once_with(q_app.return_value.exec_())
+
+
+@patch(
+    "midi_app_controller.gui.midi_status.QMessageBox.question",
+    return_value=QMessageBox.Yes,
+)
+def test_delete_binds(mock_question, midi_status, patch_rtmidi, qtbot):
+    state_manager = get_state_manager()
+    state_manager.delete_binds = MagicMock()
+    binds_names, controller_names = patch_rtmidi
+
+    qtbot.keyClicks(midi_status.current_controller, controller_names[0].name)
+    QTest.qWait(300)
+    qtbot.keyClicks(midi_status.current_binds, binds_names[0].name)
+    QTest.qWait(300)
+
+    qtbot.mouseClick(midi_status.delete_binds_button, Qt.LeftButton)
+    QTest.qWait(300)
+
+    assert mock_question.called
+    state_manager.delete_binds.assert_called_once()

--- a/midi_app_controller/gui/binds_editor.py
+++ b/midi_app_controller/gui/binds_editor.py
@@ -473,22 +473,22 @@ class BindsEditor(QDialog):
         )
 
         # Save/exit buttons.
-        save_and_exit_button = QPushButton("Save")
-        save_and_exit_button.clicked.connect(self._save_and_exit)
-        exit_button = QPushButton("Cancel")
-        exit_button.clicked.connect(self._exit)
-        save_and_exit_button_width = save_and_exit_button.sizeHint().width()
-        exit_button_width = exit_button.sizeHint().width()
+        self.save_and_exit_button = QPushButton("Save")
+        self.save_and_exit_button.clicked.connect(self._save_and_exit)
+        self.exit_button = QPushButton("Cancel")
+        self.exit_button.clicked.connect(self._exit)
+        save_and_exit_button_width = self.save_and_exit_button.sizeHint().width()
+        exit_button_width = self.exit_button.sizeHint().width()
         button_width = max(save_and_exit_button_width, exit_button_width)
 
-        save_and_exit_button.setFixedWidth(button_width)
-        exit_button.setFixedWidth(button_width)
+        self.save_and_exit_button.setFixedWidth(button_width)
+        self.exit_button.setFixedWidth(button_width)
 
         buttons_layout = QHBoxLayout()
         spacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
         buttons_layout.addItem(spacer)
-        buttons_layout.addWidget(exit_button)
-        buttons_layout.addWidget(save_and_exit_button)
+        buttons_layout.addWidget(self.exit_button)
+        buttons_layout.addWidget(self.save_and_exit_button)
 
         self.tab_widget = QTabWidget()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,13 @@ midi-app-controller = "midi_app_controller:napari.yaml"
 testing = [
     "pytest>=8.2.0",
     "pytest-cov>=5.0.0",
+    "pytest-qt>=4.0.2"
 ]
 dev = [
     "midi-app-controller[testing]",
     "pre-commit>=3.7.0",
 ]
+
 
 [tool.setuptools.packages.find]
 namespaces = false


### PR DESCRIPTION
Added tests to binds editor (100% coverage) and midi status (80% coverage), and editing github workflow according to https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html