### PR TITLE
Better YAML fields order

### DIFF
--- a/config_files/binds/sample_binds.yaml
+++ b/config_files/binds/sample_binds.yaml
@@ -1,14 +1,14 @@
 name: TestBinds
+app_name: napari
 controller_name: TestController
 description: Test description
-app_name: napari
 button_binds:
-- action_id: napari:window:view:toggle_viewer_axes
-  button_id: 0
+- button_id: 0
+  action_id: napari:window:view:toggle_viewer_axes
 knob_binds:
-- action_id_decrease: napari:layer:toggle_visibility
+- knob_id: 2
   action_id_increase: napari:layer:toggle_visibility
-  knob_id: 2
-- action_id_decrease: napari:layer:duplicate
+  action_id_decrease: napari:layer:toggle_visibility
+- knob_id: 3
   action_id_increase: napari:layer:duplicate
-  knob_id: 3
+  action_id_decrease: napari:layer:duplicate

--- a/config_files/binds/x_touch_mini_test.yaml
+++ b/config_files/binds/x_touch_mini_test.yaml
@@ -1,16 +1,16 @@
+name: XTM_binds
 app_name: napari
-button_binds:
-- action_id: napari:window:view:toggle_viewer_axes
-  button_id: 8
-- action_id: napari:layer:toggle_visibility
-  button_id: 9
 controller_name: X_TOUCH_MINI
 description: xtouchmini_test
+button_binds:
+- button_id: 8
+  action_id: napari:window:view:toggle_viewer_axes
+- button_id: 9
+  action_id: napari:layer:toggle_visibility
 knob_binds:
-- action_id_decrease: napari:layer:toggle_visibility
+- knob_id: 1
   action_id_increase: napari:layer:toggle_visibility
-  knob_id: 1
-- action_id_decrease: napari:layer:duplicate
+  action_id_decrease: napari:layer:toggle_visibility
+- knob_id: 2
   action_id_increase: napari:layer:duplicate
-  knob_id: 2
-name: XTM_binds
+  action_id_decrease: napari:layer:duplicate

--- a/config_files/controllers/sample_controller.yaml
+++ b/config_files/controllers/sample_controller.yaml
@@ -1,13 +1,13 @@
 name: TestController
 button_value_off: 0
 button_value_on: 127
+knob_value_min: 0
+knob_value_max: 127
 buttons:
 - id: 0
   name: Button1
 - id: 1
   name: Button2
-knob_value_min: 0
-knob_value_max: 127
 knobs:
 - id: 2
   name: Knob1

--- a/config_files/controllers/x_touch_mini_example.yaml
+++ b/config_files/controllers/x_touch_mini_example.yaml
@@ -1,6 +1,8 @@
 name: X_TOUCH_MINI
 button_value_off: 0
 button_value_on: 127
+knob_value_min: 0
+knob_value_max: 127
 buttons:
 - id: 8
   name: Button1A
@@ -18,8 +20,6 @@ buttons:
   name: Button7A
 - id: 15
   name: Button8A
-knob_value_min: 0
-knob_value_max: 127
 knobs:
 - id: 1
   name: Knob1A

--- a/docs/binds.md
+++ b/docs/binds.md
@@ -5,9 +5,9 @@ Ids of the elements should match the ones specified in the controller's schema.
 
 ## All available fields
 - `name`: The name of the binds set. Cannot be empty. Must be unique among all binds sets.
-- `description`: Additional information that the user may provide. Is optional.
 - `app_name`: For which app are the binds intended. Cannot be empty.
-- `controller_name`: For which controller are the binds intended.
+- `controller_name`: For which controller are the binds intended. Cannot be empty.
+- `description`: Additional information that the user may provide. Is optional.
 - `button_binds`: List of bound buttons. Each of them consists of:
   - `button_id`: The id of the button. Should be in the range `[0, 127]`.
   - `action_id`: The id of an action to be executed when the button is pressed.
@@ -19,9 +19,9 @@ Ids of the elements should match the ones specified in the controller's schema.
 ## Example
 ```yaml
 name: "MyBinds"
-description: "Optional description"
 app_name: "MyApp"
 controller_name: "MyController"
+description: "Optional description"
 button_binds:
   - button_id: 1
     action_id: "action_1"

--- a/midi_app_controller/models/_tests/test_utils.py
+++ b/midi_app_controller/models/_tests/test_utils.py
@@ -20,7 +20,7 @@ class OtherTempYamlModel(YamlBaseModel):
 
 @pytest.fixture
 def yaml_data():
-    return {"key1": "value1", "key2": "value2", "key3": ["a", "b"], "key4": None}
+    return {"key2": "value2", "key1": "value1", "key3": ["a", "b"], "key4": None}
 
 
 @pytest.fixture

--- a/midi_app_controller/models/_tests/test_utils.py
+++ b/midi_app_controller/models/_tests/test_utils.py
@@ -8,8 +8,8 @@ from ..utils import find_duplicate, YamlBaseModel
 
 
 class TempYamlModel(YamlBaseModel):
-    key1: str
     key2: str
+    key1: str
     key3: List[str]
     key4: Optional[int]
 
@@ -25,8 +25,8 @@ def yaml_data():
 
 @pytest.fixture
 def yaml_str(yaml_data):
-    dumped = yaml.safe_dump(yaml_data, default_flow_style=False)
-    assert dumped == "key1: value1\nkey2: value2\nkey3:\n- a\n- b\nkey4: null\n"
+    dumped = yaml.safe_dump(yaml_data, default_flow_style=False, sort_keys=False)
+    assert dumped == "key2: value2\nkey1: value1\nkey3:\n- a\n- b\nkey4: null\n"
     return dumped
 
 

--- a/midi_app_controller/models/binds.py
+++ b/midi_app_controller/models/binds.py
@@ -44,12 +44,10 @@ class Binds(YamlBaseModel):
     ----------
     name : str
         The name of the binds set. Cannot be empty. Must be unique among all binds sets.
-    description : Optional[str]
-        Additional information that the user may provide.
     app_name : str
         For which app are the binds intended. Cannot be empty.
     controller_name : str
-        For which controller are the binds intended.
+        For which controller are the binds intended. Cannot be empty.
     button_binds : List[ButtonBind]
         A list of bound buttons.
     knob_binds : List[KnobBind]
@@ -57,9 +55,9 @@ class Binds(YamlBaseModel):
     """
 
     name: str = Field(min_length=1)
-    description: Optional[str]
     app_name: str = Field(min_length=1)
-    controller_name: str
+    controller_name: str = Field(min_length=1)
+    description: Optional[str]
     button_binds: List[ButtonBind]
     knob_binds: List[KnobBind]
 

--- a/midi_app_controller/models/utils.py
+++ b/midi_app_controller/models/utils.py
@@ -57,7 +57,12 @@ class YamlBaseModel(BaseModel):
             YAML file path.
         """
         with open(path, "w") as f:
-            yaml.safe_dump(self.dict(), f, default_flow_style=False)
+            yaml.safe_dump(
+                self.dict(),
+                f,
+                default_flow_style=False,  # collections always serialized in the block style
+                sort_keys=False,  # keys in the order of declaration
+            )
 
 
 def find_duplicate(values: List[Any]) -> Optional[Any]:


### PR DESCRIPTION
When saving data in YAML files, fields are now stored in their declaration order, rather than being sorted alphabetically.