### PR TITLE
Update Codecov action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,8 @@ jobs:
         run: pytest --cov midi_app_controller
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: matrix.python-version == '3.12'
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Uploading coverage to Codecov often fails recently. It will probably be fixed by updating the action to `v4`. The new version does not support tokenless upload.