### PR TITLE
Allow setting only one action for knobs

### DIFF
--- a/midi_app_controller/actions/_tests/test_bound_controller.py
+++ b/midi_app_controller/actions/_tests/test_bound_controller.py
@@ -13,13 +13,20 @@ def binds() -> Binds:
         "description": "Test description",
         "app_name": "TestApp",
         "controller_name": "TestController",
-        "button_binds": [{"button_id": 1, "action_id": "Action1"}],
+        "button_binds": [
+            {"button_id": 1, "action_id": "Action1"},
+        ],
         "knob_binds": [
             {
                 "knob_id": 2,
                 "action_id_increase": "incr",
                 "action_id_decrease": "decr",
-            }
+            },
+            {
+                "knob_id": 3,
+                "action_id_increase": "incr",
+                "action_id_decrease": None,
+            },
         ],
     }
     return Binds(**binds_data)
@@ -33,8 +40,24 @@ def controller() -> Controller:
         "button_value_on": 100,
         "knob_value_min": 33,
         "knob_value_max": 55,
-        "buttons": [{"id": 0, "name": "Button1"}, {"id": 1, "name": "Button2"}],
-        "knobs": [{"id": 2, "name": "Knob1"}, {"id": 3, "name": "Knob2"}],
+        "buttons": [
+            {"id": 0, "name": "Button1"},
+            {"id": 1, "name": "Button2"},
+        ],
+        "knobs": [
+            {
+                "id": 2,
+                "name": "Knob1",
+            },
+            {
+                "id": 3,
+                "name": "Knob2",
+            },
+            {
+                "id": 5,
+                "name": "Knob3",
+            },
+        ],
     }
     return Controller(**controller_data)
 
@@ -101,8 +124,16 @@ def test_bound_controller(binds, controller, actions):
         assert bound_button.action_press.id == bind.action_id
     for bind in binds.knob_binds:
         bound_knob = bound_controller.knobs[bind.knob_id]
-        assert bound_knob.action_increase.id == bind.action_id_increase
-        assert bound_knob.action_decrease.id == bind.action_id_decrease
+        assert (
+            bound_knob.action_increase is None
+            and bind.action_id_increase is None
+            or bound_knob.action_increase.id == bind.action_id_increase
+        )
+        assert (
+            bound_knob.action_decrease is None
+            and bind.action_id_decrease is None
+            or bound_knob.action_decrease.id == bind.action_id_decrease
+        )
 
 
 @pytest.mark.parametrize("action_index_to_delete", [0, 1, 2])
@@ -147,7 +178,7 @@ def test_get_knob_increase_action(actions, bound_controller):
     assert bound_controller.get_knob_increase_action(2) == actions[1]
 
 
-@pytest.mark.parametrize("knob_id", [3, 10, 1000])
+@pytest.mark.parametrize("knob_id", [5, 10, 1000])
 def test_get_knob_increase_action_when_not_found(bound_controller, knob_id):
     assert bound_controller.get_knob_increase_action(knob_id) is None
 

--- a/midi_app_controller/actions/_tests/test_bound_controller.py
+++ b/midi_app_controller/actions/_tests/test_bound_controller.py
@@ -125,15 +125,11 @@ def test_bound_controller(binds, controller, actions):
     for bind in binds.knob_binds:
         bound_knob = bound_controller.knobs[bind.knob_id]
         assert (
-            bound_knob.action_increase is None
-            and bind.action_id_increase is None
-            or bound_knob.action_increase.id == bind.action_id_increase
-        )
+            bound_knob.action_increase is None and bind.action_id_increase is None
+        ) or bound_knob.action_increase.id == bind.action_id_increase
         assert (
-            bound_knob.action_decrease is None
-            and bind.action_id_decrease is None
-            or bound_knob.action_decrease.id == bind.action_id_decrease
-        )
+            bound_knob.action_decrease is None and bind.action_id_decrease is None
+        ) or bound_knob.action_decrease.id == bind.action_id_decrease
 
 
 @pytest.mark.parametrize("action_index_to_delete", [0, 1, 2])

--- a/midi_app_controller/actions/bound_controller.py
+++ b/midi_app_controller/actions/bound_controller.py
@@ -23,14 +23,14 @@ class KnobActions(BaseModel):
 
     Attributes
     ----------
-    action_increase : CommandRule
+    action_increase : Optional[CommandRule]
         Action to be executed when the knob's value increases.
-    action_decrease : CommandRule
+    action_decrease : Optional[CommandRule]
         Action to be executed when the knob's value decreases.
     """
 
-    action_increase: CommandRule
-    action_decrease: CommandRule
+    action_increase: Optional[CommandRule]
+    action_decrease: Optional[CommandRule]
 
 
 class BoundController(BaseModel):
@@ -108,11 +108,11 @@ class BoundController(BaseModel):
         for bind in binds.knob_binds:
             action_increase = actions_dict.get(bind.action_id_increase)
             action_decrease = actions_dict.get(bind.action_id_decrease)
-            if action_increase is None:
+            if bind.action_id_increase is not None and action_increase is None:
                 raise ValueError(
                     f"bound action '{bind.action_id_increase}' cannot be found"
                 )
-            if action_decrease is None:
+            if bind.action_id_decrease is not None and action_decrease is None:
                 raise ValueError(
                     f"bound action '{bind.action_id_decrease}' cannot be found"
                 )
@@ -142,6 +142,7 @@ class BoundController(BaseModel):
 
     def get_button_press_action(self, button_id: int) -> Optional[CommandRule]:
         """Finds the action to be executed when a button is pressed.
+
         Returns None if there is no such action.
         """
         button = self.buttons.get(button_id)
@@ -150,6 +151,7 @@ class BoundController(BaseModel):
 
     def get_knob_increase_action(self, knob_id: int) -> Optional[CommandRule]:
         """Finds action to be executed when knob's value is increased.
+
         Returns None if there is no such action.
         """
         knob = self.knobs.get(knob_id)
@@ -158,6 +160,7 @@ class BoundController(BaseModel):
 
     def get_knob_decrease_action(self, knob_id: int) -> Optional[CommandRule]:
         """Finds action to be executed when knob's value is decreased.
+
         Returns None if there is no such action.
         """
         knob = self.knobs.get(knob_id)


### PR DESCRIPTION
Allow setting action for only one of `increase` or `decrease`.

Currently, there is an exception when one clicks `Start handling` with such binds (which are validated correctly when saving them).