### PR TITLE
Remove flexparser pin, drop python 3.9m and python on CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
+      - name: Install system deps for python-rtmidi (ALSA)
+        run: |
+          sudo apt update
+          sudo apt install -y libasound2-dev
+
       - name: Build
         run: python -m pip install -e .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: 👷 Build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
-      - name: Install alsa deps
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libasound2-dev
+      - name: Install system deps for python-rtmidi (ALSA)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt update
+          sudo apt install -y libasound2-dev
 
       - name: Setup headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,12 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
-      - name: Install system dependencies for gui testing (libxkbcommon-x11-0)
+      - name: Install system dependencies (GUI + python-rtmidi / ALSA)
         run: |
           sudo apt update
-          sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1 libdbus-1-3
+          sudo apt install -y \
+            libasound2-dev \
+            libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1 libdbus-1-3
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,12 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-    env:
-      DISPLAY: ':99.0'
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -25,6 +24,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: pyproject.toml
+
+      - name: Install alsa deps
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install libasound2-dev
 
       - name: Setup headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
-      - name: Install system dependencies (GUI + python-rtmidi / ALSA)
-        run: |
-          sudo apt update
-          sudo apt install -y \
-            libasound2-dev \
-            libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1 libdbus-1-3
-          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
+        with:
+          qt: true
+          wm: herbstluftwm
 
       - name: Install dependencies
         run: pip install -e .[testing]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     env:
       DISPLAY: ':99.0'
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+midi_app_controller/_version.py
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ state = get_state_manager()
 
 ## Development
 
+### System dependencies
+
+This package depends on [`python-rtmidi`](https://github.com/SpotlightKid/python-rtmidi). On many platforms pip installs a pre-built wheel; on **Linux** you often build from source, which needs **ALSA** development headers (pkg-config name `alsa`):
+
+- **Ubuntu / Debian:** `sudo apt install libasound2-dev`
+- **Fedora / RHEL-like:** `sudo dnf install alsa-lib-devel`
+
+Without these, `pip install` can fail during metadata/build with `Dependency "alsa" not found`. On macOS and Windows, wheels are more common; if compilation is triggered, follow python-rtmidi’s build notes for your OS.
+
 ### Installing
 ```sh
 python3 -m pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
+    # pint<0.24.4 breaks on Python 3.13 (frozen dataclass inheritance); napari pulls pint transitively
+    "pint>=0.24.4",
     "napari>=0.4.19",
     "python-rtmidi>=1.5.8",
     "pyyaml>=6.0.1",
@@ -38,7 +40,6 @@ testing = [
     "pytest-cov>=5.0.0",
     "pytest-qt>=4.0.2",
     "napari[all]",  # ensures Qt backend available for testing
-    "flexparser!=0.4.0"  # see https://napari.zulipchat.com/#narrow/channel/212875-general/topic/broken.20pint.2Fflexparser/near/481110284
 ]
 dev = [
     "midi-app-controller[testing]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Framework :: napari",
     "Programming Language :: Python",


### PR DESCRIPTION
Closes #123. Co-authored with @Czaki 

This PR does the following:

- Updates lowest version support to Python 3.10
- Bumps pint version to support change in frozen dataclass enforcement in Python 3.13 and above
- Remove unneeded flexparser dependency

Recommend updating CI to 3.10+ as well.