### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install system deps for python-rtmidi (ALSA)
+        run: |
+          sudo apt update
+          sudo apt install -y libasound2-dev
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
 
 
   upload-to-pypi:
@@ -33,9 +33,9 @@ jobs:
       url: https://pypi.org/p/midi-app-controller
     steps:
       - name: Download built artifact to dist/
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
+  pull_request:
   push:
-    branches: [main]
     tags: [v*]
 
 concurrency:
@@ -10,36 +10,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
+  build-and-inspect-package:
+    name: Build & inspect package.
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hynek/build-and-inspect-python-package@v2
+
+
+  upload-to-pypi:
+    name: Upload package to PyPI
+    needs: build-and-inspect-package
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing, but
+      # should NOT be granted anywhere else!
+      id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-pypi-project-name>
-    permissions:
-      id-token: write
-      contents: write
+      url: https://pypi.org/p/midi-app-controller
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
+          name: Packages
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.9"
-
-      - name: 👷 Build
-        run: |
-          python -m pip install build
-          python -m build
-
-      - name: 🚢 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-
-      - uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          generate_release_notes: true
-          files: "./dist/*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install system deps for python-rtmidi (ALSA)
         run: |
           sudo apt update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dev = [
     "pre-commit>=3.7.0",
 ]
 
-[tool.setuptools.packages.find]
-namespaces = true
+[tool.setuptools]
+packages = ["midi_app_controler"]
 
 [tool.setuptools_scm]
 write_to = "midi_app_controller/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["midi_app_controler"]
+packages = ["midi_app_controller"]
 
 [tool.setuptools_scm]
 write_to = "midi_app_controller/_version.py"


### PR DESCRIPTION
Split build package from upload steep. Use hynek/build-and-inspect-python-package to properly validate package 

Depends on #124